### PR TITLE
feat: replace inputoptions with auro-checkbox #13

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "auro-react-demo",
-  "version": "0.1.0",
+  "version": "1.0.2",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -59,24 +59,6 @@
       "requires": {
         "chalk": "^3.0.0",
         "copyfiles": "^2.3.0",
-        "lit-element": "^2.3.1"
-      },
-      "dependencies": {
-        "lit-element": {
-          "version": "2.3.1",
-          "resolved": "https://registry.npmjs.org/lit-element/-/lit-element-2.3.1.tgz",
-          "integrity": "sha512-tOcUAmeO3BzwiQ7FGWdsshNvC0HVHcTFYw/TLIImmKwXYoV0E7zCBASa8IJ7DiP4cen/Yoj454gS0qqTnIGsFA==",
-          "requires": {
-            "lit-html": "^1.1.1"
-          }
-        }
-      }
-    },
-    "@alaskaairux/ods-inputoptions": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/@alaskaairux/ods-inputoptions/-/ods-inputoptions-2.0.2.tgz",
-      "integrity": "sha512-RwejWiAf75EUapJrZvKx4ad24to7dGEg8UDtarJczXgDcuF9JlwKBS0oanRJ0PUgkLGcW/+drDVyBhVmkFQn3Q==",
-      "requires": {
         "lit-element": "^2.3.1"
       },
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -6,7 +6,6 @@
     "@alaskaairux/auro-checkbox": "^1.1.0",
     "@alaskaairux/ods-button": "^4.6.1",
     "@alaskaairux/ods-hyperlink": "^1.5.1",
-    "@alaskaairux/ods-inputoptions": "^2.0.2",
     "@alaskaairux/ods-toast": "^1.1.2",
     "@alaskaairux/orion-design-tokens": "^2.11.0",
     "@alaskaairux/orion-icons": "^2.1.5",

--- a/src/App.js
+++ b/src/App.js
@@ -1,4 +1,4 @@
-import React, { useState } from 'react';
+import React, { useState, useRef, useEffect } from 'react';
 import './App.scss';
 
 import Swipe from "@alaskaairux/ods-toast/dist/swipe.js";
@@ -24,12 +24,26 @@ function App() {
       checked: false
     }
   ]);
+
+  // Because the change event from auro-checkbox is a custom event, onChange does not pick it up
+  // due to React's synthetic event system
+  // We need to add the event listener using a ref instead
+  // If you do not need to support IE, you can listen to the input event inline instead of using a ref.
+  const checkboxGroupEl = useRef(null);
+  useEffect(() => {
+    const checkboxGroup = checkboxGroupEl.current;
+    checkboxGroup.addEventListener('change', handleChange);
+    return function cleanup() {
+      checkboxGroup.removeEventListener('change', handleChange);
+    };
+  });
+
   const changeType = () => {
     const newType = type === 'primary' ? 'secondary' : 'primary';
     setType(newType);
   }
 
-  const handleInput = (e) => {
+  const handleChange = (e) => {
     const { target } = e;
 
     let updatedOptions = options.map(
@@ -45,14 +59,24 @@ function App() {
 
   return (
     <main>
-	    <h1 class="heading--display">Web Component Demo</h1>
-      <ods-inputoption-checkbox-group
-        label={`Your Choice: ${JSON.stringify(options.filter(option => option.checked).map(option => option.value))}`}
-        for="cbxDemo1">
-        {options.map(
-          option =>
-            <ods-inputoption id={option.id} label={option.label} type="checkbox" value={option.value} checked={option.checked || undefined} onInput={handleInput}></ods-inputoption>)}
-	    </ods-inputoption-checkbox-group>
+      <h1 className="heading--display">Web Component Demo</h1>
+      <auro-checkbox-group required ref={checkboxGroupEl}>
+        <span slot="legend">{`Your Choice: ${JSON.stringify(
+          options
+            .filter((option) => option.checked)
+            .map((option) => option.value)
+        )}`}</span>
+        {options.map((option) => (
+          <auro-checkbox
+            key={option.id}
+            id={option.id}
+            name="cbxDemo"
+            value={option.value}
+            checked={option.checked || undefined}>
+            {option.label}
+          </auro-checkbox>
+        ))}
+      </auro-checkbox-group>
       <auro-button onClick={toast} secondary={type === 'secondary' || undefined}>Toast</auro-button>
       <auro-button onClick={changeType}>Change Toaster</auro-button>
     </main>

--- a/src/webcomponents.js
+++ b/src/webcomponents.js
@@ -1,5 +1,5 @@
 /* Import any web components used here */
 import '@alaskaairux/ods-button/dist/auro-button';
-import '@alaskaairux/ods-inputoptions/dist/ods-inputoption';
-import '@alaskaairux/ods-inputoptions/dist/ods-inputoption-checkbox-group';
+import '@alaskaairux/auro-checkbox';
+import '@alaskaairux/auro-checkbox/dist/auro-checkbox-group';
 import '@alaskaairux/ods-toast';


### PR DESCRIPTION
# Alaska Airlines Pull Request

This updates the demo to use auro-checkbox instead of ods-inputoptions.

Fixes #13

## Summary:

This replaces ods-inputoptions with auro-checkbox to align this project with AuroSvelteDemo. 

Note that for IE11 support, we have to use a ref to add the change listener to the checkbox group. The change event is not composed and will not escape the shadow DOM on its own, so we have to re-dispatch it from the checkbox component. This seems to prevent React's synthetic event system from picking it up.

If we no longer have to support IE11, we can listen to the input event inline instead.

## Type of change:

Please delete options that are not relevant.

- [x] Revision of an existing capability


## Checklist:

- [x] My update follows the CONTRIBUTING guidelines of this project
- [x] I have performed a self-review of my own update

**By submitting this Pull Request, I confirm that my contribution is made under the terms of the Apache 2.0 license.**

_Pull Requests will be evaluated by their quality of update and whether it is consistent with the goals and values of this project. Any submission is to be considered a conversation between the submitter and the maintainers of this project and may require changes to your submission._ 

**Thank you for your submission!**<br>
-- Orion Design System Team
